### PR TITLE
feat: add launch_command config option for auto-running commands on n…

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -125,6 +125,7 @@ max_depth: 3
 excluded_dirs: [node_modules, vendor, .git]
 default_session_name: main
 container_timeout_seconds: 300
+launch_command: "claude"  # Command to run when a new tmux session is created
 
 auth:
   credentials:
@@ -133,6 +134,7 @@ auth:
       value: ~/.claude/.credentials
   projects:
     my-project:
+      launch_command: "npm run dev"  # Per-project override
       credentials:
         - name: API_KEY
           source: env

--- a/internal/auth/resolver.go
+++ b/internal/auth/resolver.go
@@ -67,6 +67,17 @@ func (c *Config) Resolve(projectName string) *ResolveResult {
 	return result
 }
 
+// ResolveLaunchCommand returns the launch command for a project.
+// Returns the project-specific command if set, otherwise the global default.
+func (c *Config) ResolveLaunchCommand(projectName, globalDefault string) string {
+	if c != nil {
+		if proj, ok := c.Projects[projectName]; ok && proj.LaunchCommand != "" {
+			return proj.LaunchCommand
+		}
+	}
+	return globalDefault
+}
+
 // resolveCredential resolves a single credential from its source.
 func resolveCredential(cred Credential) (string, error) {
 	switch cred.Source {

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -36,6 +36,8 @@ type Credential struct {
 type ProjectAuth struct {
 	// Credentials overrides the global credentials for this project.
 	Credentials []Credential `yaml:"credentials,omitempty"`
+	// LaunchCommand is the command to run when a new tmux session is created.
+	LaunchCommand string `yaml:"launch_command,omitempty"`
 }
 
 // Config holds the authentication configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	ExcludedDirs       []string    `yaml:"excluded_dirs"`
 	DefaultSessionName string      `yaml:"default_session_name"`
 	ContainerTimeout   int         `yaml:"container_timeout_seconds"`
+	LaunchCommand      string      `yaml:"launch_command,omitempty"`
 	Auth               auth.Config `yaml:"auth,omitempty"`
 }
 

--- a/internal/devcontainer/tmux_ops.go
+++ b/internal/devcontainer/tmux_ops.go
@@ -32,8 +32,9 @@ func ListTmuxSessions(projectPath string) ([]string, error) {
 	return sessions, nil
 }
 
-// CreateTmuxSession creates a new tmux session in the container
-func CreateTmuxSession(projectPath, sessionName string) error {
+// CreateTmuxSession creates a new tmux session in the container.
+// If launchCommand is non-empty, it will be sent to the session after creation.
+func CreateTmuxSession(projectPath, sessionName, launchCommand string) error {
 	// Read credentials BEFORE creating session so they're available to the initial shell
 	creds := readCredentialFile(projectPath)
 
@@ -54,6 +55,11 @@ func CreateTmuxSession(projectPath, sessionName string) error {
 
 	// Also set via setenv for any new windows/panes created later
 	injectTmuxSessionEnv(projectPath, sessionName)
+
+	// Run launch command if specified
+	if launchCommand != "" {
+		execInContainer(projectPath, "tmux", "send-keys", "-t", sessionName, launchCommand, "Enter")
+	}
 
 	return nil
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -140,8 +140,10 @@ func (m Model) restartTmuxSession() tea.Cmd {
 		if err := devcontainer.KillTmuxSession(m.selectedInstance.Path, sessionName); err != nil {
 			return containerErrorMsg{err: err}
 		}
+		// Resolve launch command (project-specific or global default)
+		launchCmd := m.config.Auth.ResolveLaunchCommand(m.selectedInstance.Name, m.config.LaunchCommand)
 		// Create new session with same name
-		if err := devcontainer.CreateTmuxSession(m.selectedInstance.Path, sessionName); err != nil {
+		if err := devcontainer.CreateTmuxSession(m.selectedInstance.Path, sessionName, launchCmd); err != nil {
 			return containerErrorMsg{err: err}
 		}
 		return tmuxSessionRestartedMsg{}
@@ -175,7 +177,9 @@ func (m Model) createTmuxSession(name string) tea.Cmd {
 		if m.selectedInstance == nil {
 			return containerErrorMsg{err: errNoInstanceSelected}
 		}
-		if err := devcontainer.CreateTmuxSession(m.selectedInstance.Path, name); err != nil {
+		// Resolve launch command (project-specific or global default)
+		launchCmd := m.config.Auth.ResolveLaunchCommand(m.selectedInstance.Name, m.config.LaunchCommand)
+		if err := devcontainer.CreateTmuxSession(m.selectedInstance.Path, name, launchCmd); err != nil {
 			return containerErrorMsg{err: err}
 		}
 		return tmuxSessionCreatedMsg{}


### PR DESCRIPTION
…ew tmux sessions

Allows users to specify a command (e.g., "claude") that runs automatically when a new tmux session is created. Supports both global default and per-project overrides via the auth.projects section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)