### PR TITLE
feat: add dark/light mode toggle with t keybinding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     "TERM": "xterm-256color",
     "LANG": "en_US.UTF-8"
   },
-  "postCreateCommand": "npm install -g @anthropic-ai/claude-code",
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && go build -o claude-quick .",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	DefaultSessionName string      `yaml:"default_session_name"`
 	ContainerTimeout   int         `yaml:"container_timeout_seconds"`
 	LaunchCommand      string      `yaml:"launch_command,omitempty"`
+	DarkMode           *bool       `yaml:"dark_mode,omitempty"`
 	Auth               auth.Config `yaml:"auth,omitempty"`
 }
 
@@ -124,4 +125,12 @@ func expandPath(path string) string {
 // ConfigPath returns the path where the config file should be located
 func ConfigPath() string {
 	return configPath()
+}
+
+// IsDarkMode returns the dark mode setting, defaulting to true if not set
+func (c *Config) IsDarkMode() bool {
+	if c.DarkMode == nil {
+		return true // Default to dark mode for backwards compatibility
+	}
+	return *c.DarkMode
 }

--- a/internal/tui/container.go
+++ b/internal/tui/container.go
@@ -213,8 +213,9 @@ func RenderDashboard(instances []devcontainer.ContainerInstanceWithStatus, curso
 	b.WriteString("\n")
 
 	// Key bindings - second row with right-aligned detach hint
-	leftKeys := fmt.Sprintf("  %s  %s  %s",
+	leftKeys := fmt.Sprintf("  %s  %s  %s  %s",
 		RenderKeyBinding("R", "refresh"),
+		RenderKeyBinding("t", "theme"),
 		RenderKeyBinding("?", "config"),
 		RenderKeyBinding("q", "quit"),
 	)

--- a/internal/tui/handlers.go
+++ b/internal/tui/handlers.go
@@ -130,6 +130,12 @@ func (m Model) handleDashboardKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.previousState = m.state
 		m.state = StateShowConfig
 		return m, nil
+
+	case "t":
+		// Toggle dark/light theme
+		m.darkMode = !m.darkMode
+		ApplyTheme(m.darkMode)
+		return m, nil
 	}
 	return m, nil
 }
@@ -213,6 +219,12 @@ func (m Model) handleTmuxSelectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "?":
 		m.previousState = m.state
 		m.state = StateShowConfig
+		return m, nil
+
+	case "t":
+		// Toggle dark/light theme
+		m.darkMode = !m.darkMode
+		ApplyTheme(m.darkMode)
 		return m, nil
 
 	case "enter":

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -30,6 +30,7 @@ type Model struct {
 	config           *config.Config
 	previousState    State
 	authWarning      string // Warning message if auth credentials failed to resolve
+	darkMode         bool   // Current theme mode (true = dark, false = light)
 }
 
 // getInstanceName safely returns the selected instance display name
@@ -67,6 +68,10 @@ func newTextInput(placeholder string) textinput.Model {
 
 // New creates a new Model with discovered instances
 func New(instances []devcontainer.ContainerInstance, cfg *config.Config) Model {
+	// Initialize theme from config
+	darkMode := cfg.IsDarkMode()
+	ApplyTheme(darkMode)
+
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = SpinnerStyle
@@ -78,11 +83,16 @@ func New(instances []devcontainer.ContainerInstance, cfg *config.Config) Model {
 		textInput:     newTextInput(cfg.DefaultSessionName),
 		worktreeInput: newTextInput(constants.DefaultWorktreePlaceholder),
 		config:        cfg,
+		darkMode:      darkMode,
 	}
 }
 
 // NewWithDiscovery creates a Model that will discover instances asynchronously
 func NewWithDiscovery(cfg *config.Config) Model {
+	// Initialize theme from config
+	darkMode := cfg.IsDarkMode()
+	ApplyTheme(darkMode)
+
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = SpinnerStyle
@@ -94,6 +104,7 @@ func NewWithDiscovery(cfg *config.Config) Model {
 		textInput:     newTextInput(cfg.DefaultSessionName),
 		worktreeInput: newTextInput(constants.DefaultWorktreePlaceholder),
 		config:        cfg,
+		darkMode:      darkMode,
 	}
 }
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -2,97 +2,192 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
-// Colors - Claude Code inspired palette
-var (
-	colorOrange    = lipgloss.Color("#E07A5F") // Anthropic orange (terracotta/salmon)
-	colorWhite     = lipgloss.Color("#FFFFFF") // White for selected items
-	colorDim       = lipgloss.Color("#6B7280") // Gray for dimmed text
-	colorSuccess   = lipgloss.Color("#10B981") // Green for running
-	colorWarning   = lipgloss.Color("#F59E0B") // Yellow/amber for stopped
-	colorError     = lipgloss.Color("#EF4444") // Red for errors
-	colorSeparator = lipgloss.Color("#4B5563") // Darker gray for separators
-)
+// colorPalette holds all colors for a theme
+type colorPalette struct {
+	orange    lipgloss.Color
+	primary   lipgloss.Color
+	dim       lipgloss.Color
+	success   lipgloss.Color
+	warning   lipgloss.Color
+	errorCol  lipgloss.Color
+	separator lipgloss.Color
+}
 
-// Styles
+// Dark mode palette (for dark terminal backgrounds)
+var darkPalette = colorPalette{
+	orange:    lipgloss.Color("#E07A5F"), // Anthropic orange (terracotta/salmon)
+	primary:   lipgloss.Color("#FFFFFF"), // White for primary text
+	dim:       lipgloss.Color("#6B7280"), // Gray for dimmed text
+	success:   lipgloss.Color("#10B981"), // Green for running
+	warning:   lipgloss.Color("#F59E0B"), // Yellow/amber for stopped
+	errorCol:  lipgloss.Color("#EF4444"), // Red for errors
+	separator: lipgloss.Color("#4B5563"), // Darker gray for separators
+}
+
+// Light mode palette (for light terminal backgrounds)
+var lightPalette = colorPalette{
+	orange:    lipgloss.Color("#C45A3E"), // Darker orange for contrast
+	primary:   lipgloss.Color("#1F2937"), // Dark gray for primary text
+	dim:       lipgloss.Color("#6B7280"), // Medium gray
+	success:   lipgloss.Color("#059669"), // Darker green
+	warning:   lipgloss.Color("#D97706"), // Darker amber
+	errorCol:  lipgloss.Color("#DC2626"), // Darker red
+	separator: lipgloss.Color("#9CA3AF"), // Light gray borders
+}
+
+// currentPalette holds the active color palette
+var currentPalette = darkPalette
+
+// IsDarkMode tracks the current theme state
+var IsDarkMode = true
+
+// Styles - initialized with dark mode colors
 var (
 	// Header title style (Anthropic orange)
 	TitleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(colorOrange)
+			Foreground(currentPalette.orange)
 
 	// Subtitle style
 	SubtitleStyle = lipgloss.NewStyle().
-			Foreground(colorDim)
+			Foreground(currentPalette.dim)
 
-	// Selected item style - white bold (no background)
+	// Selected item style - bold primary color (no background)
 	SelectedStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(colorWhite)
+			Foreground(currentPalette.primary)
 
 	// Unselected item style
 	ItemStyle = lipgloss.NewStyle().
-			Foreground(colorWhite)
+			Foreground(currentPalette.primary)
 
 	// Dimmed item style (for paths, details)
 	DimmedStyle = lipgloss.NewStyle().
-			Foreground(colorDim)
+			Foreground(currentPalette.dim)
 
 	// Help text style
 	HelpStyle = lipgloss.NewStyle().
-			Foreground(colorDim)
+			Foreground(currentPalette.dim)
 
 	// Error style
 	ErrorStyle = lipgloss.NewStyle().
-			Foreground(colorError).
+			Foreground(currentPalette.errorCol).
 			Bold(true)
 
 	// Success style
 	SuccessStyle = lipgloss.NewStyle().
-			Foreground(colorSuccess)
+			Foreground(currentPalette.success)
 
 	// Warning style
 	WarningStyle = lipgloss.NewStyle().
-			Foreground(colorWarning)
+			Foreground(currentPalette.warning)
 
 	// Box style for containers
 	BoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorDim).
+			BorderForeground(currentPalette.dim).
 			Padding(0, 1)
 
 	// Input style for text input
 	InputStyle = lipgloss.NewStyle().
-			Foreground(colorWhite)
+			Foreground(currentPalette.primary)
 
 	// Spinner style
 	SpinnerStyle = lipgloss.NewStyle().
-			Foreground(colorOrange)
+			Foreground(currentPalette.orange)
 
 	// Separator style
 	SeparatorStyle = lipgloss.NewStyle().
-			Foreground(colorSeparator)
+			Foreground(currentPalette.separator)
 
 	// Key highlight style (for keybinding display)
 	KeyStyle = lipgloss.NewStyle().
-			Foreground(colorWhite)
+			Foreground(currentPalette.primary)
 
 	// Column header style
 	ColumnHeaderStyle = lipgloss.NewStyle().
-				Foreground(colorDim).
+				Foreground(currentPalette.dim).
 				Bold(true)
 )
 
 // Status text styles with labels
 var (
-	StatusRunning = lipgloss.NewStyle().Foreground(colorSuccess)
-	StatusStopped = lipgloss.NewStyle().Foreground(colorWarning)
-	StatusUnknown = lipgloss.NewStyle().Foreground(colorDim)
+	StatusRunning = lipgloss.NewStyle().Foreground(currentPalette.success)
+	StatusStopped = lipgloss.NewStyle().Foreground(currentPalette.warning)
+	StatusUnknown = lipgloss.NewStyle().Foreground(currentPalette.dim)
 )
+
+// ApplyTheme updates all styles based on the dark mode setting
+func ApplyTheme(darkMode bool) {
+	IsDarkMode = darkMode
+	if darkMode {
+		currentPalette = darkPalette
+	} else {
+		currentPalette = lightPalette
+	}
+
+	// Rebuild all styles with the new palette
+	TitleStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(currentPalette.orange)
+
+	SubtitleStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.dim)
+
+	SelectedStyle = lipgloss.NewStyle().
+		Bold(true).
+		Foreground(currentPalette.primary)
+
+	ItemStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.primary)
+
+	DimmedStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.dim)
+
+	HelpStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.dim)
+
+	ErrorStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.errorCol).
+		Bold(true)
+
+	SuccessStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.success)
+
+	WarningStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.warning)
+
+	BoxStyle = lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(currentPalette.dim).
+		Padding(0, 1)
+
+	InputStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.primary)
+
+	SpinnerStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.orange)
+
+	SeparatorStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.separator)
+
+	KeyStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.primary)
+
+	ColumnHeaderStyle = lipgloss.NewStyle().
+		Foreground(currentPalette.dim).
+		Bold(true)
+
+	// Status styles
+	StatusRunning = lipgloss.NewStyle().Foreground(currentPalette.success)
+	StatusStopped = lipgloss.NewStyle().Foreground(currentPalette.warning)
+	StatusUnknown = lipgloss.NewStyle().Foreground(currentPalette.dim)
+}
 
 // Cursor returns the selection cursor (› instead of >)
 func Cursor() string {
 	return lipgloss.NewStyle().
-		Foreground(colorOrange).
+		Foreground(currentPalette.orange).
 		Bold(true).
 		Render("› ")
 }

--- a/internal/tui/tmux.go
+++ b/internal/tui/tmux.go
@@ -76,7 +76,8 @@ func RenderTmuxSelect(projectName string, sessions []tmux.Session, cursor int, a
 	b.WriteString("\n")
 
 	// Key bindings - second row with right-aligned detach hint
-	leftKeys := fmt.Sprintf("  %s  %s",
+	leftKeys := fmt.Sprintf("  %s  %s  %s",
+		RenderKeyBinding("t", "theme"),
 		RenderKeyBinding("?", "config"),
 		RenderKeyBinding("q", "back"),
 	)


### PR DESCRIPTION
- Add dark_mode config option (defaults to true for backwards compatibility)
- Add ApplyTheme() function with dark and light color palettes
- Press 't' to toggle theme at runtime on dashboard and tmux select views
- Theme resets to config default on app restart
- Update help text to show new keybinding

🤖 Generated with [Claude Code](https://claude.com/claude-code)