### PR TITLE
feat: auto-push new worktree branches upstream

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ContainerTimeout   int         `yaml:"container_timeout_seconds"`
 	LaunchCommand      string      `yaml:"launch_command,omitempty"`
 	DarkMode           *bool       `yaml:"dark_mode,omitempty"`
+	AutoPushWorktree   *bool       `yaml:"auto_push_worktree,omitempty"`
 	Auth               auth.Config `yaml:"auth,omitempty"`
 }
 
@@ -133,4 +134,12 @@ func (c *Config) IsDarkMode() bool {
 		return true // Default to dark mode for backwards compatibility
 	}
 	return *c.DarkMode
+}
+
+// IsAutoPushWorktree returns whether to auto-push new worktree branches upstream
+func (c *Config) IsAutoPushWorktree() bool {
+	if c.AutoPushWorktree == nil {
+		return true // Default to enabled
+	}
+	return *c.AutoPushWorktree
 }

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -232,10 +232,14 @@ func (m Model) createWorktree(branchName string) tea.Cmd {
 		if m.selectedInstance == nil {
 			return containerErrorMsg{err: errNoInstanceSelected}
 		}
-		worktreePath, err := devcontainer.CreateWorktree(m.selectedInstance.Path, branchName)
+		worktreePath, pushWarning, err := devcontainer.CreateWorktree(
+			m.selectedInstance.Path,
+			branchName,
+			m.config.IsAutoPushWorktree(),
+		)
 		if err != nil {
 			return containerErrorMsg{err: err}
 		}
-		return worktreeCreatedMsg{worktreePath: worktreePath}
+		return worktreeCreatedMsg{worktreePath: worktreePath, pushWarning: pushWarning}
 	}
 }

--- a/internal/tui/container.go
+++ b/internal/tui/container.go
@@ -116,7 +116,7 @@ func RenderRefreshingStatus(spinnerView string) string {
 }
 
 // RenderDashboard renders the container dashboard with status indicators
-func RenderDashboard(instances []devcontainer.ContainerInstanceWithStatus, cursor int, width int) string {
+func RenderDashboard(instances []devcontainer.ContainerInstanceWithStatus, cursor int, width int, warning string) string {
 	if width <= 0 {
 		width = defaultWidth
 	}
@@ -126,6 +126,12 @@ func RenderDashboard(instances []devcontainer.ContainerInstanceWithStatus, curso
 	// Bordered header
 	b.WriteString(RenderBorderedHeader("claude-quick", "Container Dashboard", width))
 	b.WriteString("\n\n")
+
+	// Show warning if present
+	if warning != "" {
+		b.WriteString(WarningStyle.Render("Warning: " + warning))
+		b.WriteString("\n\n")
+	}
 
 	if len(instances) == 0 {
 		b.WriteString(ErrorStyle.Render("No devcontainer projects found."))

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -48,6 +48,7 @@ type tmuxDetachedMsg struct{}
 // worktreeCreatedMsg is sent when a new git worktree is created
 type worktreeCreatedMsg struct {
 	worktreePath string
+	pushWarning  string
 }
 
 // worktreeDeletedMsg is sent when a git worktree is deleted

--- a/internal/tui/tmux.go
+++ b/internal/tui/tmux.go
@@ -12,7 +12,7 @@ import (
 const newSessionOption = "[+ New Session]"
 
 // RenderTmuxSelect renders the tmux session selection view
-func RenderTmuxSelect(projectName string, sessions []tmux.Session, cursor int, authWarning string) string {
+func RenderTmuxSelect(projectName string, sessions []tmux.Session, cursor int, warning string) string {
 	width := defaultWidth
 
 	var b strings.Builder
@@ -21,9 +21,9 @@ func RenderTmuxSelect(projectName string, sessions []tmux.Session, cursor int, a
 	b.WriteString(RenderBorderedHeader("claude-quick", "tmux Sessions: "+projectName, width))
 	b.WriteString("\n\n")
 
-	// Show auth warning if present
-	if authWarning != "" {
-		b.WriteString(WarningStyle.Render("Auth warning: " + authWarning))
+	// Show warning if present
+	if warning != "" {
+		b.WriteString(WarningStyle.Render("Warning: " + warning))
 		b.WriteString("\n\n")
 	}
 


### PR DESCRIPTION
Automatically pushes new git worktree branches to origin with upstream tracking configured when creating a new worktree. This eliminates the manual git setup required before Claude can start working effectively.

- Add `auto_push_worktree` config option (default: enabled)
- Add `git push -u origin <branch>` after worktree creation
- Show warning on dashboard/tmux select if push fails
- Only push for newly created branches, not existing ones
- Rename `authWarning` to generic `warning` for reusability

🤖 Generated with [Claude Code](https://claude.com/claude-code)