### PR TITLE
feat: move config location to executable directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Constraints:
 
 ## Configuration
 
-Config file: `~/.config/claude-quick/config.yaml`
+Config file location (in priority order):
+1. **Recommended**: `claude-quick.yaml` next to the executable (for `build.sh` installs, this is the repo root)
+2. **Legacy** (deprecated): `~/.config/claude-quick/config.yaml`
 
 ```yaml
 search_paths:
@@ -97,7 +99,17 @@ max_depth: 3
 default_session_name: main
 ```
 
-See [`config.example.yaml`](config.example.yaml) for all options.
+### Migrating from Legacy Location
+
+If you have an existing config at `~/.config/claude-quick/config.yaml`:
+
+```bash
+cp ~/.config/claude-quick/config.yaml /path/to/claude-quick/claude-quick.yaml
+```
+
+The legacy location will still work but shows a deprecation warning.
+
+See [`claude-quick.yaml.example`](claude-quick.yaml.example) for all options.
 
 ## Authentication
 

--- a/claude-quick.yaml.example
+++ b/claude-quick.yaml.example
@@ -1,5 +1,7 @@
 # Claude Quick Configuration
-# Copy this file to ~/.config/claude-quick/config.yaml
+# This file should be placed next to the claude-quick executable as 'claude-quick.yaml'.
+# For build.sh installs: place in the repo root directory.
+# Legacy location (~/.config/claude-quick/config.yaml) is still supported but deprecated.
 
 # Directories to scan for devcontainer projects
 # Supports ~ for home directory expansion

--- a/claude.md
+++ b/claude.md
@@ -17,7 +17,7 @@ User → TUI (Bubble Tea) → devcontainer CLI → Docker → tmux sessions
 claude-quick/
 ├── main.go                    # Entry point: loads config, validates CLI, launches TUI
 ├── internal/
-│   ├── config/config.go       # YAML config loading from ~/.config/claude-quick/config.yaml
+│   ├── config/config.go       # YAML config loading (executable dir or ~/.config/claude-quick/)
 │   ├── constants/constants.go # Default values, timeouts, display limits
 │   ├── auth/                  # Credential management
 │   │   ├── types.go           # Credential, SourceType (file/env/command)
@@ -116,7 +116,9 @@ Parallel goroutines query Docker status for all instances simultaneously.
 
 ## Configuration
 
-Location: `~/.config/claude-quick/config.yaml`
+Location (in priority order):
+1. `claude-quick.yaml` next to executable (following symlinks)
+2. `~/.config/claude-quick/config.yaml` (legacy, deprecated)
 
 ```yaml
 search_paths:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -10,6 +11,21 @@ import (
 	"github.com/christophergyman/claude-quick/internal/util"
 	"gopkg.in/yaml.v3"
 )
+
+// ConfigSource represents where the config was loaded from
+type ConfigSource int
+
+const (
+	ConfigSourceExecutable ConfigSource = iota // New location (co-located with executable)
+	ConfigSourceLegacy                         // Legacy ~/.config location
+	ConfigSourceDefault                        // No config file found, using defaults
+)
+
+// configInfo holds information about the resolved config location
+var configInfo struct {
+	Path   string
+	Source ConfigSource
+}
 
 // getHomeDir returns the user's home directory with fallback to /tmp
 func getHomeDir() string {
@@ -49,8 +65,25 @@ func DefaultConfig() *Config {
 	}
 }
 
-// configPath returns the path to the config file
-func configPath() string {
+// executableDir returns the directory containing the resolved executable
+// (follows symlinks to find the real location)
+func executableDir() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	// Follow symlinks to get the real path
+	realPath, err := filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve symlinks: %w", err)
+	}
+
+	return filepath.Dir(realPath), nil
+}
+
+// legacyConfigPath returns the legacy config path (~/.config/claude-quick/config.yaml)
+func legacyConfigPath() string {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
 		configDir = filepath.Join(getHomeDir(), ".config")
@@ -58,18 +91,60 @@ func configPath() string {
 	return filepath.Join(configDir, "claude-quick", "config.yaml")
 }
 
+// configPath resolves the config file path with the following priority:
+// 1. Config file co-located with executable (new location)
+// 2. Legacy ~/.config/claude-quick/config.yaml location
+// Returns the path and the source type
+func configPath() (string, ConfigSource) {
+	// Try executable directory first (new location)
+	if execDir, err := executableDir(); err == nil {
+		newPath := filepath.Join(execDir, "claude-quick.yaml")
+		if _, err := os.Stat(newPath); err == nil {
+			return newPath, ConfigSourceExecutable
+		}
+	}
+
+	// Fall back to legacy location
+	legacyPath := legacyConfigPath()
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, ConfigSourceLegacy
+	}
+
+	// No config found - return new location path for error messages
+	if execDir, err := executableDir(); err == nil {
+		return filepath.Join(execDir, "claude-quick.yaml"), ConfigSourceDefault
+	}
+
+	// If executable dir cannot be determined, use legacy path as reference
+	return legacyPath, ConfigSourceDefault
+}
+
 // Load reads the configuration from the config file
 // Falls back to defaults if the file doesn't exist
+// Prints deprecation warning if using legacy location
 func Load() (*Config, error) {
 	cfg := DefaultConfig()
 
-	path := configPath()
+	path, source := configPath()
+	configInfo.Path = path
+	configInfo.Source = source
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return cfg, nil
 		}
 		return nil, err
+	}
+
+	// Print deprecation warning if using legacy location
+	if source == ConfigSourceLegacy {
+		targetPath := path
+		if execDir, err := executableDir(); err == nil {
+			targetPath = filepath.Join(execDir, "claude-quick.yaml")
+		}
+		fmt.Fprintf(os.Stderr, "Warning: Config loaded from deprecated location %s\n", path)
+		fmt.Fprintf(os.Stderr, "         Consider moving to %s\n\n", targetPath)
 	}
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {
@@ -113,9 +188,23 @@ func Load() (*Config, error) {
 	return cfg, nil
 }
 
-// ConfigPath returns the path where the config file should be located
+// ConfigPath returns the path where the config file is/should be located
 func ConfigPath() string {
-	return configPath()
+	if configInfo.Path != "" {
+		return configInfo.Path
+	}
+	path, _ := configPath()
+	return path
+}
+
+// GetConfigSource returns the source of the loaded configuration
+func GetConfigSource() ConfigSource {
+	return configInfo.Source
+}
+
+// IsUsingLegacyConfig returns true if config was loaded from legacy location
+func IsUsingLegacyConfig() bool {
+	return configInfo.Source == ConfigSourceLegacy
 }
 
 // IsDarkMode returns the dark mode setting, defaulting to true if not set

--- a/internal/tui/container.go
+++ b/internal/tui/container.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/christophergyman/claude-quick/internal/config"
 	"github.com/christophergyman/claude-quick/internal/constants"
 	"github.com/christophergyman/claude-quick/internal/devcontainer"
 )
@@ -138,7 +139,7 @@ func RenderDashboard(instances []devcontainer.ContainerInstanceWithStatus, curso
 		b.WriteString("\n\n")
 		b.WriteString(DimmedStyle.Render("Add search paths to: "))
 		b.WriteString("\n")
-		b.WriteString(DimmedStyle.Render("~/.config/claude-quick/config.yaml"))
+		b.WriteString(DimmedStyle.Render(config.ConfigPath()))
 		return b.String()
 	}
 


### PR DESCRIPTION
- Config now loads from claude-quick.yaml next to the executable (following symlinks)
- Falls back to legacy ~/.config/claude-quick/config.yaml with deprecation warning
- Renamed config.example.yaml to claude-quick.yaml.example
- Updated documentation in README.md and claude.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)