### PR TITLE
chore: Documentation and codebase cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,6 @@
 ![Claude Quick](claude-quick-pic.png)
 A terminal UI for managing tmux sessions across your devcontainers.
 
-
-## Quick Start
-
-```bash
-# Install
-go install github.com/christophergyman/claude-quick@latest
-
-# Run
-claude-quick
-```
-
 ## Requirements
 
 - Go 1.25+
@@ -23,21 +12,25 @@ claude-quick
 
 ## Installation
 
-**Go Install** (recommended)
 ```bash
 go install github.com/christophergyman/claude-quick@latest
 ```
 
-**Build from Source**
+Or build from source:
 ```bash
 git clone https://github.com/christophergyman/claude-quick.git
 cd claude-quick
 go build -o claude-quick .
 ```
 
-**Build Script** (runs tests, builds, symlinks to ~/.local/bin)
+Or use the build script (runs tests, builds, symlinks to ~/.local/bin):
 ```bash
 ./build.sh
+```
+
+Then run:
+```bash
+claude-quick
 ```
 
 ## Testing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,15 +28,6 @@ var configInfo struct {
 	Source ConfigSource
 }
 
-// getHomeDir returns the user's home directory with fallback to /tmp
-func getHomeDir() string {
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		return homeDir
-	}
-	// Fallback to /tmp if home directory cannot be determined
-	return os.TempDir()
-}
-
 // Config holds the application configuration
 type Config struct {
 	SearchPaths        []string      `yaml:"search_paths"`
@@ -59,7 +50,7 @@ func DefaultExcludedDirs() []string {
 // DefaultConfig returns the default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		SearchPaths:        []string{getHomeDir()},
+		SearchPaths:        []string{util.HomeDir()},
 		MaxDepth:           constants.DefaultMaxDepth,
 		ExcludedDirs:       DefaultExcludedDirs(),
 		DefaultSessionName: constants.DefaultSessionName,
@@ -89,7 +80,7 @@ func executableDir() (string, error) {
 func legacyConfigPath() string {
 	configDir, err := os.UserConfigDir()
 	if err != nil {
-		configDir = filepath.Join(getHomeDir(), ".config")
+		configDir = filepath.Join(util.HomeDir(), ".config")
 	}
 	return filepath.Join(configDir, "claude-quick", "config.yaml")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,23 +93,6 @@ func boolPtr(b bool) *bool {
 	return &b
 }
 
-func TestGetHomeDir(t *testing.T) {
-	result := getHomeDir()
-
-	// Should return a non-empty string
-	if result == "" {
-		t.Error("getHomeDir() returned empty string")
-	}
-
-	// Should be either home dir or temp dir
-	homeDir, _ := os.UserHomeDir()
-	tempDir := os.TempDir()
-
-	if result != homeDir && result != tempDir {
-		t.Errorf("getHomeDir() = %q, expected home dir %q or temp dir %q", result, homeDir, tempDir)
-	}
-}
-
 func TestLoad_NonexistentFile(t *testing.T) {
 	// Load should return defaults when file doesn't exist
 	// This test assumes the config file doesn't exist in the test environment

--- a/internal/devcontainer/doc.go
+++ b/internal/devcontainer/doc.go
@@ -1,0 +1,35 @@
+// Package devcontainer handles container lifecycle and git operations.
+//
+// # Overview
+//
+// This package provides functionality for:
+//   - Discovering devcontainer projects in search paths
+//   - Managing container lifecycle (start, stop, restart)
+//   - Git worktree operations
+//   - tmux session management within containers
+//
+// # Key Types
+//
+//   - ContainerInstance: Represents a discovered devcontainer project
+//   - WorktreeInfo: Git worktree metadata (branch, path, main repo status)
+//
+// # Key Files
+//
+//   - discovery.go: Recursive devcontainer.json scanner
+//   - docker.go: Container lifecycle (up, stop, restart, status checks)
+//   - git.go: Worktree detection, creation, deletion, branch validation
+//   - tmux_ops.go: Session management, credential injection
+//   - types.go: Type definitions
+//
+// # Container Identification
+//
+// Uses Docker label queries for reliability:
+//
+//	docker ps --filter label=devcontainer.local_folder=<path>
+//
+// # Git Worktree Integration
+//
+// Each worktree is treated as a separate devcontainer instance.
+// Worktrees share the same devcontainer.json from the main repo.
+// The container mounts the main repo's .git directory for git operations.
+package devcontainer

--- a/internal/devcontainer/tmux_ops.go
+++ b/internal/devcontainer/tmux_ops.go
@@ -20,7 +20,7 @@ func ListTmuxSessions(projectPath string) ([]string, error) {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
 			return []string{}, nil
 		}
-		return nil, fmt.Errorf("ListTmuxSessions: %w", err)
+		return nil, fmt.Errorf("failed to list tmux sessions: %w", err)
 	}
 
 	var sessions []string

--- a/internal/tui/doc.go
+++ b/internal/tui/doc.go
@@ -1,0 +1,38 @@
+// Package tui implements the terminal user interface using Bubble Tea.
+//
+// # Architecture
+//
+// The TUI operates as a deterministic state machine. The Model struct holds
+// all application state, and the Update method handles all state transitions
+// in response to messages.
+//
+// # State Machine
+//
+// Key states include:
+//   - StateDashboard: Main container list view
+//   - StateContainerStarting/Stopping: Container operations in progress
+//   - StateTmuxSelect: Session picker after container starts
+//   - StateNewWorktreeInput: Creating git worktree
+//   - StateGitHubIssueSelect: GitHub issue selection for worktree names
+//
+// All transitions are explicit via message handling in Update().
+//
+// # Async Command Pattern
+//
+// No blocking I/O in the UI. Operations return tea.Cmd that execute async:
+//
+//	discoverInstances() → instancesDiscoveredMsg
+//	startContainer()    → containerStartedMsg
+//	loadTmuxSessions()  → tmuxSessionsLoadedMsg
+//
+// # Key Files
+//
+//   - model.go: Model definition and Update/View methods
+//   - state.go: State constants and transitions
+//   - handlers.go: Keyboard event handlers
+//   - commands.go: Async command implementations
+//   - messages.go: Message types for async results
+//   - container.go: Dashboard rendering
+//   - tmux.go: Session selection rendering
+//   - styles.go: Lipgloss styling
+package tui

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -14,13 +14,13 @@ func ExpandPath(path string) string {
 		return path
 	}
 	if path[0] == '~' {
-		return filepath.Join(getHomeDir(), path[1:])
+		return filepath.Join(HomeDir(), path[1:])
 	}
 	return path
 }
 
-// getHomeDir returns the user's home directory with fallback to temp directory.
-func getHomeDir() string {
+// HomeDir returns the user's home directory with fallback to temp directory.
+func HomeDir() string {
 	if homeDir, err := os.UserHomeDir(); err == nil {
 		return homeDir
 	}

--- a/internal/util/path_test.go
+++ b/internal/util/path_test.go
@@ -88,12 +88,12 @@ func TestExpandPath_TildeExpansion(t *testing.T) {
 	}
 }
 
-func TestGetHomeDir(t *testing.T) {
-	result := getHomeDir()
+func TestHomeDir(t *testing.T) {
+	result := HomeDir()
 
 	// Should return a non-empty string
 	if result == "" {
-		t.Error("getHomeDir() returned empty string")
+		t.Error("HomeDir() returned empty string")
 	}
 
 	// Should be a valid directory path (either home or temp)
@@ -102,9 +102,9 @@ func TestGetHomeDir(t *testing.T) {
 
 	if homeErr == nil && result != homeDir {
 		// If we can get home dir, result should match
-		t.Errorf("getHomeDir() = %q, want %q", result, homeDir)
+		t.Errorf("HomeDir() = %q, want %q", result, homeDir)
 	} else if homeErr != nil && result != tempDir {
 		// If home dir fails, should fall back to temp
-		t.Errorf("getHomeDir() = %q, want temp dir %q", result, tempDir)
+		t.Errorf("HomeDir() = %q, want temp dir %q", result, tempDir)
 	}
 }


### PR DESCRIPTION
## Summary

Addresses #23 - Documentation and codebase cleanup for improved readability.

- **README.md**: Removed redundant Quick Start section, reordered sections for logical flow (Requirements → Installation → Testing → Usage), added explicit "Run" instruction
- **Package documentation**: Added `doc.go` files for `tui` and `devcontainer` packages with comprehensive architecture docs
- **Code deduplication**: Exported `HomeDir()` from util package, removed duplicate from config package
- **Error message consistency**: Fixed function name prefix in tmux_ops.go error message

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Verified README reads well with new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)